### PR TITLE
feat: Add support for executing custom user data

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
   repository_level:
     description: "Set to true to enable repository level registration token"
     default: "false"
+  custom_script:
+    description: "Custom user script to run (as root) before starting the runner"
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -90,6 +93,17 @@ runs:
           sudo -E -u ghrunner ./config.sh --unattended --url https://github.com/${{ steps.get-registration.outputs.runner_scope }} \
             --token ${{ steps.get-registration.outputs.registration_token }} --name $(hostname) --work /home/ghrunner \
             --labels ${{ steps.get-registration.outputs.runner_scope }} --ephemeral
+
+          # Running custom script if provided
+          if [[ -n "${{ inputs.custom_script }}" ]]; then
+            CUSTOM_SCRIPT=$(mktemp $HOME/custom_script.XXXXXX.sh)
+            cat > $CUSTOM_SCRIPT <<'CUSTOM_SCRIPT_EOF'
+            ${{ inputs.custom_script }}
+            CUSTOM_SCRIPT_EOF
+            chmod 0700 $CUSTOM_SCRIPT
+            echo "Running custom user script"
+            sudo $CUSTOM_SCRIPT
+          fi
 
           # Install and start the runner service
           ./svc.sh install


### PR DESCRIPTION
This commit introduces the ability to run a custom script prior to installing and starting the runner service. Users can now pass custom script (runs as sudo) to configure their runners with specific requirements before the runner is fully initialized.

A new input parameter `custom_script` has been added. It accepts a string value representing the custom script. If this parameter is provided, the script will be executed before the runner service starts, allowing for custom configurations or setup tasks to be performed seamlessly.

Address: #13